### PR TITLE
fix: currency fallback

### DIFF
--- a/actions/pdp-renderer/lib.js
+++ b/actions/pdp-renderer/lib.js
@@ -93,7 +93,7 @@ async function prepareBaseTemplate(url, blocks) {
 function getFormatter(locale = 'us-en', currency) {
   return new Intl.NumberFormat(locale, {
       style: 'currency',
-      currency: currency || 'USD',
+      currency: (!currency || currency === 'NONE') ? 'USD' : currency,
       minimumFractionDigits: 2,
       maximumFractionDigits: 2
   });


### PR DESCRIPTION
Added one case when currency needs to fall back to the default one: when string `NONE` is returned by CS.
Otherwise the renderer will fail with a 500 and a RangeError for the intl formatter