### PR TITLE
Fix/poller deadlock during deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 # package directories
 node_modules
 jspm_packages
@@ -44,3 +43,11 @@ logs
 *.env
 *.aio.json
 .aem-commerce-prerender.json
+
+# New additions
+/node_modules
+/.parcel-cache
+/web-src/src/config.json
+/coverage
+/.npmrc
+/bin/redeploy-poller.sh

--- a/.gitignore
+++ b/.gitignore
@@ -43,11 +43,3 @@ logs
 *.env
 *.aio.json
 .aem-commerce-prerender.json
-
-# New additions
-/node_modules
-/.parcel-cache
-/web-src/src/config.json
-/coverage
-/.npmrc
-/bin/redeploy-poller.sh

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Pluggable prerendering stack for ahead-of-time data fetching and embedding in Pr
   1. Then generate a repo with the relevant code in your org by clicking [here](https://github.com/new?template_name=aem-commerce-prerender&template_owner=adobe-rnd). You can now clone the resulting repo from your org, and run `npm i && npx setup`
   1. Follow the steps to perform the initial setup
   1. Customise the code that contains the rendering logic according to your requirements, for [structured data](/actions/pdp-renderer/ldJson.js), [markup](/actions/pdp-renderer/render.js) and [templates](https://github.com/adobe-rnd/aem-commerce-prerender/tree/main/actions/pdp-renderer/templates) - more info [here](/docs/CUSTOMIZE.md)
-  1. Deploy the solution with `aio app deploy`
+  1. Deploy the solution with `npm run deploy`
 
 ### What's next?
  You might want to check out the [instructions and guidelines](/docs/POST-SETUP.md) around operation and maintenance of the solution

--- a/docs/CUSTOMIZE.md
+++ b/docs/CUSTOMIZE.md
@@ -1,5 +1,7 @@
 # Rendering Logic & Customizations
 
+To apply your changes and customizations to the js or templating logic, you have to run the command `npm run deploy` which will take care of delivering the new code and restarting the change detector.
+
 ## Structured data
 
 ### GTIN & Product Codes

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "e2e": "node --experimental-vm-modules node_modules/jest/bin/jest.js --collectCoverage=false --testRegex ./e2e",
     "lint": "eslint --ignore-pattern web-src --no-error-on-unmatched-pattern test src actions",
     "lint:fix": "npm run lint -- --fix",
-    "redeploy:poller": "bin/redeploy-poller.sh"
+    "deploy": "tools/deploy.sh"
   },
   "engines": {
     "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --passWithNoTests ./test",
     "e2e": "node --experimental-vm-modules node_modules/jest/bin/jest.js --collectCoverage=false --testRegex ./e2e",
     "lint": "eslint --ignore-pattern web-src --no-error-on-unmatched-pattern test src actions",
-    "lint:fix": "npm run lint -- --fix"
+    "lint:fix": "npm run lint -- --fix",
+    "redeploy:poller": "bin/redeploy-poller.sh"
   },
   "engines": {
     "node": ">=18"

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+    
+echo "checking poller run state..."
+running_state=$(aio app state get running)
+if [ "$running_state" = "true" ]; then
+    echo "poller mutex is set to true, resetting to false" && \
+    aio app state put running false
+else
+    echo "poller is not running (state: $running_state)"
+fi
+rm -r dist/
+aio app deploy && \
+echo "app deployed!"


### PR DESCRIPTION
In case an error happens, the state with key "running" might not be updated to "false" and this will prevent new executions of the poller.
Due to the 1h TTL the value should be reset in such cases, but of course this happens with a long delay.
fix #141 