### PR TITLE
Fix/batch process unpublish stall

### DIFF
--- a/actions/lib/aem.js
+++ b/actions/lib/aem.js
@@ -303,7 +303,7 @@ class AdminAPI {
                 : records.filter(record => record.liveUnpublishedAt).map(record => record.path);
 
             if (paths.length === 0) {
-                logger.warn(`Skipping unpublish for route=${route} in batch id=${batchNumber} for locale=${locale}: no paths to process.`);
+                logger.info(`Skipping unpublish for route=${route} in batch id=${batchNumber} for locale=${locale}: no paths to process.`);
                 batch.resolve({ records, locale, batchNumber });
                 complete();
                 return;

--- a/actions/lib/observability.js
+++ b/actions/lib/observability.js
@@ -7,7 +7,7 @@ class ObservabilityClient {
       this.org = options.org;
       this.site = options.site;
       this.endpoint = options.endpoint;
-      this. nativeLogger = nativeLogger;
+      this.nativeLogger = nativeLogger;
   }
 
   getEndpoints(type) {


### PR DESCRIPTION
-this fix prevent the stall in case unpublish has failed for one or more batches and therefore the `liveUnpublishedAt` of theitr entries is undefined/null.
Since those entries are filtered by that timestamp, the resulting `paths` filtered array (which is then required by the API) is empty, and  the request to AEM Admin API is not processable.