### PR TITLE
fix: unpublish

### DIFF
--- a/actions/check-product-changes/poller.js
+++ b/actions/check-product-changes/poller.js
@@ -288,12 +288,7 @@ async function processDeletedProducts(remainingSkus, state, context, adminApi) {
       const batches = createBatches(deletedProducts, context);
       const pendingBatches = [];
       for (let batchNumber = 0; batchNumber < batches.length; batchNumber++) {
-        const records = batches[batchNumber].map((product) => {
-          return {
-            sku: product.sku,
-            path: getProductUrl(product, context, false).toLowerCase(),
-          };
-        });
+        const records = batches[batchNumber];
         const pendingBatch = adminApi.unpublishAndDelete(records, locale, batchNumber + 1)
           .then(({ records }) => {
             records.forEach((record) => {

--- a/actions/check-product-changes/poller.js
+++ b/actions/check-product-changes/poller.js
@@ -295,15 +295,11 @@ async function processDeletedProducts(remainingSkus, state, context, adminApi) {
               if (record.liveUnpublishedAt && record.previewUnpublishedAt) {
                 // Delete the HTML file from public storage
                 try {
-                  const product = deletedProducts.find(p => p.sku === record.sku);
-                  if (product) {
-                    const productUrl = getProductUrl({ urlKey: product.urlKey, sku: product.sku }, context, false).toLowerCase();
-                    const htmlPath = `/public/pdps${productUrl}`;
-                    filesLib.delete(htmlPath);
-                    logger.debug(`Deleted HTML file for product ${record.sku} from ${htmlPath}`);
-                  }
+                  const htmlPath = `/public/pdps${record.path}`;
+                  filesLib.delete(htmlPath);
+                  logger.debug(`Deleted HTML file for product ${record.sku} from ${htmlPath}`);
                 } catch (e) {
-                  logger.error(`Error deleting HTML file for product ${record.sku}:`, e);
+                  logger.warn(`Error deleting HTML file for product ${record.sku}:`, e);
                 }
 
                 delete state.skus[record.sku];

--- a/test/check-product-changes.test.js
+++ b/test/check-product-changes.test.js
@@ -47,7 +47,7 @@ jest.mock('../actions/utils', () => ({
   requestSaaS: jest.fn(),
   requestSpreadsheet: jest.fn(),
   isValidUrl: jest.fn(() => true),
-  getProductUrl: jest.fn(({ urlKey, sku }) => `/${urlKey || sku}`),
+  getProductUrl: jest.fn(({ urlKey }) => `/p/${urlKey}`),
   getDefaultStoreURL: jest.fn(() => 'https://content.com'),
   formatMemoryUsage: jest.fn(() => '100MB'),
   FILE_PREFIX: 'check-product-changes',
@@ -302,14 +302,14 @@ describe('Poller', () => {
 
       // Verify HTML file was saved
       expect(filesLib.write).toHaveBeenCalledWith(
-        '/public/pdps/url-sku-123.html',
+        '/public/pdps/p/url-sku-123.html',
         '<html>Product 123</html>'
       );
 
       // Verify API calls
       expect(AdminAPI.prototype.previewAndPublish).toHaveBeenCalledWith(
           expect.arrayContaining([
-            expect.objectContaining({ path: '/url-sku-123', sku: 'sku-123' })
+            expect.objectContaining({ path: '/p/url-sku-123', sku: 'sku-123' })
           ]),
           null,
           1
@@ -528,8 +528,8 @@ describe('Poller', () => {
       requestSpreadsheet.mockImplementation(() => {
         return Promise.resolve({
           data: [
-            { sku: 'sku-123', urlKey: 'url-sku-123' },
-            { sku: 'sku-456', urlKey: 'url-sku-456' }
+            { sku: 'sku-123', path: '/p/url-sku-123' },
+            { sku: 'sku-456', path: '/p/url-sku-456' }
           ],
         });
       });
@@ -537,8 +537,9 @@ describe('Poller', () => {
       // Mock successful unpublish
       AdminAPI.prototype.unpublishAndDelete.mockImplementation((batch) => {
         return Promise.resolve({
-          records: batch.map(({ sku }) => ({
+          records: batch.map(({ sku, path }) => ({
             sku,
+            path,
             liveUnpublishedAt: new Date(),
             previewUnpublishedAt: new Date()
           }))
@@ -549,8 +550,8 @@ describe('Poller', () => {
 
       // Verify HTML files were deleted
       expect(filesLib.delete).toHaveBeenCalledTimes(2);
-      expect(filesLib.delete).toHaveBeenCalledWith('/public/pdps/url-sku-123');
-      expect(filesLib.delete).toHaveBeenCalledWith('/public/pdps/url-sku-456');
+      expect(filesLib.delete).toHaveBeenCalledWith('/public/pdps/p/url-sku-123');
+      expect(filesLib.delete).toHaveBeenCalledWith('/public/pdps/p/url-sku-456');
     });
   });
 });


### PR DESCRIPTION
The data for un-publish are based on the published-products-index, not the CS response.
The published-products-index only contains lastModified, sku, and path.
We cannot use `getProductUrl()` as we don't have the full product context (urlKey missing), but we already have the actual path the pdp was published to.