### PR TITLE
feat: localised product template; support for template caching

### DIFF
--- a/actions/pdp-renderer/render.js
+++ b/actions/pdp-renderer/render.js
@@ -84,9 +84,9 @@ async function generateProductHtml(sku, urlKey, context) {
   if (context.productsTemplate) {
     const productsTemplateURL = context.productsTemplate.replace(/\s+/g, '').replace('{locale}', localeKey);
     if (!productTemplateCache[localeKey]) productTemplateCache[localeKey] = {};
-    if (!productTemplateCache[localeKey]?.baseTemplate) productTemplateCache[localeKey].baseTemplate = await prepareBaseTemplate(productsTemplateURL, blocksToReplace);
-    
-    Handlebars.registerPartial('content', productTemplateCache[localeKey].baseTemplate);
+    if (!productTemplateCache[localeKey].baseTemplate) productTemplateCache[localeKey].baseTemplate = prepareBaseTemplate(productsTemplateURL, blocksToReplace);
+    const baseTemplate = await productTemplateCache[localeKey].baseTemplate;
+    Handlebars.registerPartial('content', baseTemplate);
   } else {
     // Use product details block as sole content if no products template is defined
     Handlebars.registerPartial('content', productDetailsHbs);

--- a/test/mock-server.js
+++ b/test/mock-server.js
@@ -49,6 +49,9 @@ const handlers = {
   defaultProductTemplate : http.get('https://content.com/products/default.plain.html', () => {
     return HttpResponse.html(mockProductTemplate);
   }),
+  localizedProductTemplate: http.get('https://content.com/en/products/default.plain.html', () => {
+    return HttpResponse.html(mockProductTemplate);
+  }),
 }
 
 function useMockServer() {


### PR DESCRIPTION
-caching for fetching product templates
-support for locales, for use cases where customers have (even slightly) different templates between different locales (or markets).
This falls back to the single default template if no `{locale}` token is included in the template URL