### PR TITLE
fix: add pathFormat to context for fetch-all-products

### DIFF
--- a/actions/fetch-all-products/index.js
+++ b/actions/fetch-all-products/index.js
@@ -102,6 +102,7 @@ async function main(params) {
     CONTENT_URL: contentUrl,
     CONFIG_NAME: configName = 'configs',
     CONFIG_SHEET: configSheet,
+    PRODUCT_PAGE_URL_FORMAT: pathFormat,
   } = params;
   if (!siteName || !orgName || !contentUrl) {
     return {
@@ -120,6 +121,7 @@ async function main(params) {
     storeUrl,
     contentUrl,
     logger: logger,
+    pathFormat,
   };
 
   const results = await Promise.all(locales.map(async (locale) => {

--- a/runners/run-fetch-all-products.js
+++ b/runners/run-fetch-all-products.js
@@ -20,6 +20,7 @@ const { main } = require('../actions/fetch-all-products/index');
             LOG_LEVEL: 'info',
             LOG_INGESTOR_ENDPOINT: process.env.LOG_INGESTOR_ENDPOINT,
             LOCALES: process.env.LOCALES,
+            PRODUCT_PAGE_URL_FORMAT: process.env.PRODUCT_PAGE_URL_FORMAT,
         });
         console.log(JSON.stringify(resp, null, 2));
     } catch (error) {


### PR DESCRIPTION
since `getConfig()` uses `getProductUrl()` to get the base path for a given locale according to the path format, we need to provide the same to the context used in the fetch-all-products action.