### PR TITLE
Sites 34439 aem admin api auth token stores personal helix admin

### DIFF
--- a/bin/setup/index.js
+++ b/bin/setup/index.js
@@ -606,7 +606,7 @@ const RULES_MAP = {
 
     static async helixConfig(request) {
       const headers = RequestHelper.extractHeaders(request);
-      const jwtBody = await AuthService.verifyJWT(headers.aemAdminToken);
+      const jwtBody = await AuthService.verifyJWT(headers.auth);
 
       if (!jwtBody.isValid) {
         return RequestHelper.errorResponse('Invalid token', 401);
@@ -648,7 +648,7 @@ const RULES_MAP = {
             envObject = dotenv.parse(envContent);
         }
 
-        envObject['AEM_ADMIN_API_AUTH_TOKEN'] = headers.aemAdminToken;
+        envObject['AEM_ADMIN_API_AUTH_TOKEN'] = headers.auth;
 
         const newEnvContent = dotenvStringify(envObject);
         fs.writeFileSync(envPath, newEnvContent);

--- a/bin/setup/index.js
+++ b/bin/setup/index.js
@@ -606,7 +606,7 @@ const RULES_MAP = {
 
     static async helixConfig(request) {
       const headers = RequestHelper.extractHeaders(request);
-      const jwtBody = await AuthService.verifyJWT(headers.auth);
+      const jwtBody = await AuthService.verifyJWT(headers.aemAdminToken);
 
       if (!jwtBody.isValid) {
         return RequestHelper.errorResponse('Invalid token', 401);
@@ -621,9 +621,9 @@ const RULES_MAP = {
         return RequestHelper.errorResponse('org and site parameters are required in URL');
       }
 
-      const { newIndexConfig, newSiteConfig, appConfigParams, aioNamespace, aioAuth } = await request.json();
-      if (!newIndexConfig || !newSiteConfig || !appConfigParams) {
-        return RequestHelper.errorResponse('newIndexConfig, newSiteConfig, and appConfigParams are required');
+      const { newIndexConfig, newSiteConfig, appConfigParams, aioNamespace, aioAuth, serviceToken } = await request.json();
+      if (!newIndexConfig || !newSiteConfig || !appConfigParams || !serviceToken) {
+        return RequestHelper.errorResponse('newIndexConfig, newSiteConfig, serviceToken, and appConfigParams are required');
       }
 
       // Generate and write app.config.yaml locally
@@ -648,7 +648,7 @@ const RULES_MAP = {
             envObject = dotenv.parse(envContent);
         }
 
-        envObject['AEM_ADMIN_API_AUTH_TOKEN'] = headers.auth;
+        envObject['AEM_ADMIN_API_AUTH_TOKEN'] = serviceToken;
 
         const newEnvContent = dotenvStringify(envObject);
         fs.writeFileSync(envPath, newEnvContent);

--- a/bin/setup/index.js
+++ b/bin/setup/index.js
@@ -321,9 +321,11 @@ const RULES_MAP = {
 
         const apiKeyEndpoint = `https://admin.hlx.page/config/${org}/profiles/${site}/apiKeys.json`;
         const body = {
-          description: `prerender_key:${org}/${site}`,
+          description: `Key used by PDP Prerender components [${org}/${site}]`,
           roles: [
-            "publish",
+            "preview",
+            "publish", 
+            "config_admin"
           ]
         };
 

--- a/bin/setup/ui/setup-wizard.js
+++ b/bin/setup/ui/setup-wizard.js
@@ -1188,8 +1188,7 @@ export class SetupWizard extends LitElement {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
-                    'X-AEM-admin-token': this.accessToken,
-                    'X-AIO-auth': this.token
+                    'X-AEM-admin-token': this.accessToken
                 },
                 body: JSON.stringify({
                     newIndexConfig: this.previewData.newIndexConfig,
@@ -1200,7 +1199,8 @@ export class SetupWizard extends LitElement {
                         ...this.advancedSettings
                     },
                     aioNamespace: this.aioNamespace,
-                    aioAuth: this.aioAuth
+                    aioAuth: this.aioAuth,
+                    serviceToken: this.token
                 })
             });
 

--- a/bin/setup/ui/setup-wizard.js
+++ b/bin/setup/ui/setup-wizard.js
@@ -1188,7 +1188,8 @@ export class SetupWizard extends LitElement {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
-                    'X-AEM-admin-token': this.token
+                    'X-AEM-admin-token': this.accessToken,
+                    'X-AIO-auth': this.token
                 },
                 body: JSON.stringify({
                     newIndexConfig: this.previewData.newIndexConfig,

--- a/bin/setup/ui/setup-wizard.js
+++ b/bin/setup/ui/setup-wizard.js
@@ -1188,7 +1188,7 @@ export class SetupWizard extends LitElement {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
-                    'X-AEM-admin-token': this.accessToken
+                    'X-AEM-admin-token': this.token
                 },
                 body: JSON.stringify({
                     newIndexConfig: this.previewData.newIndexConfig,

--- a/bin/setup/ui/setup-wizard.js
+++ b/bin/setup/ui/setup-wizard.js
@@ -698,7 +698,9 @@ export class SetupWizard extends LitElement {
             const body = {
                 description: `Key used by PDP Prerender components [${this.org}/${this.site}]`,
                 roles: [
+                    "preview",
                     "publish",
+                    "config_admin"
                 ]
             };
 

--- a/bin/setup/ui/setup-wizard.js
+++ b/bin/setup/ui/setup-wizard.js
@@ -695,64 +695,8 @@ export class SetupWizard extends LitElement {
         this.loading = true;
         try {
             const apiKeyEndpoint = `https://admin.hlx.page/config/${this.org}/sites/${this.site}/apiKeys.json`;
-
-            // First, check for existing API keys
-            console.log(`Checking for existing API keys at ${apiKeyEndpoint}`);
-
-            const getResponse = await fetch(apiKeyEndpoint, {
-                method: 'GET',
-                headers: {
-                    'authorization': `token ${this.accessToken}`
-                }
-            });
-
-            let existingKeys = {};
-
-            if (getResponse.status === 404) {
-                // 404 means no API keys exist yet, which is fine
-                console.log('No existing API keys found (404 response)');
-            } else if (!getResponse.ok) {
-                const errorText = await getResponse.text();
-                this.showToastNotification(`Failed to check existing API keys: ${getResponse.status} ${getResponse.statusText} - ${errorText}`, 'negative');
-                return false;
-            } else {
-                existingKeys = await getResponse.json();
-                console.log('Existing API keys:', existingKeys);
-            }
-
-            // Check if there's a non-expired key with the expected description
-            const expectedDescription = `prerender_key:${this.org}/${this.site}`;
-            let existingKey = null;
-            const currentTime = new Date();
-
-            if (existingKeys && typeof existingKeys === 'object') {
-                for (const [keyId, keyData] of Object.entries(existingKeys)) {
-                    if (keyData.description === expectedDescription) {
-                        const expirationDate = new Date(keyData.expiration);
-                        if (expirationDate > currentTime) {
-                            existingKey = { id: keyId, ...keyData };
-                            break;
-                        }
-                    }
-                }
-            }
-
-            if (existingKey) {
-                // Use existing key
-                console.log('Found existing non-expired API key:', existingKey);
-                this.generatedApiKey = existingKey;
-                this.token = existingKey.value || existingKey.id;
-                this.aioOrg = this.org;
-                this.aioSite = this.site;
-                await this.handleTokenChange(this.token);
-                this.showToastNotification('Using existing API key!', 'positive');
-                return true;
-            }
-
-            // No existing key found, create a new one
-            console.log('No existing API key found, creating new one');
             const body = {
-                description: expectedDescription,
+                description: `Key used by PDP Prerender components [${this.org}/${this.site}]`,
                 roles: [
                     "publish",
                 ]
@@ -760,7 +704,7 @@ export class SetupWizard extends LitElement {
 
             console.log(`Creating API key at ${apiKeyEndpoint}`);
 
-            const postResponse = await fetch(apiKeyEndpoint, {
+            const response = await fetch(apiKeyEndpoint, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -769,13 +713,13 @@ export class SetupWizard extends LitElement {
                 body: JSON.stringify(body)
             });
 
-            if (!postResponse.ok) {
-                const errorText = await postResponse.text();
-                this.showToastNotification(`Failed to create API key: ${postResponse.status} ${postResponse.statusText} - ${errorText}`, 'negative');
+            if (!response.ok) {
+                const errorText = await response.text();
+                this.showToastNotification(`Failed to create API key: ${response.status} ${response.statusText} - ${errorText}`, 'negative');
                 return false;
             }
 
-            const result = await postResponse.json();
+            const result = await response.json();
             this.generatedApiKey = result;
             // Auto-populate the AEM admin token with the generated API key value
             this.token = result.value;


### PR DESCRIPTION
This PR addresses a critical issue in our configuration. Previously, the settings relied on a personal admin Helix token, which expires every 24 hours. This approach caused authentication failures.

I replaced it with an auth key (service token), which has a 1-year expiration period and is the correct credential type for long-term use.

Additionally, this PR reverts the changes introduced in commit 2b6c301ebc4cbbf3ca1b0b1ab3e064ed354ba5d0, since it attempted to reuse a key value that cannot be retrieved once generated.